### PR TITLE
Fix error code for new nitrokey version

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -328,12 +328,10 @@ fn expand_connect(group: DeviceGroup, ret_type: &syn::ReturnType) -> Tokens {
     quote! { #connect#check }
   };
 
-  // TODO: There should be a better error code returned on the
-  //       `nitrokey` side of things.
   let skip = if let DeviceGroup::No = group {
-    quote! {let Err(::nitrokey::CommandError::Undefined) = result {} else}
+    quote! {let Err(::nitrokey::Error::CommunicationError(::nitrokey::CommunicationError::NotConnected)) = result {} else}
   } else {
-    quote! {let Err(::nitrokey::CommandError::Undefined) = result}
+    quote! {let Err(::nitrokey::Error::CommunicationError(::nitrokey::CommunicationError::NotConnected)) = result}
   };
 
   let result = if let DeviceGroup::No = group {


### PR DESCRIPTION
In nitrokey 0.4, the connect functions will return a Result&lt;_, Error&gt;
instead of a CommandError.  Connection failure will be indicated by the
CommunicationError::NotConnected variant.  This patch changes the
nitrokey error handling to use these new error types.

----
Could you release this as 0.2.0 so that I can use it in nitrokey-rs?